### PR TITLE
Added Kami, Google, FSF, GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ just a list of official company merch stores
 * [Google](https://www.googlemerchandisestore.com/)
 * [FSF (Free Software Foundation)](https://shop.fsf.org/)
 * [GitLab](https://shop.gitlab.com/)
+* [RedHat](https://store.ecompanystore.com/redhat/Shop/)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ just a list of official company merch stores
 * [Slack](https://slack-shop.myshopify.com)
 * [SpaceX](https://shop.spacex.com)
 * [Wikipedia](https://store.wikimedia.org/)
+* [Kami](https://store.kamiapp.com/)
+* [Google](https://www.googlemerchandisestore.com/)
+* [FSF (Free Software Foundation)](https://shop.fsf.org/)
+* [GitLab](https://shop.gitlab.com/)


### PR DESCRIPTION
Kami store is broken as of 14 May 2019 due to a SSL Cert misconfiguration, but I've alerted them to this.